### PR TITLE
Fix unexpected exceptions when providing inputs with more than one colons

### DIFF
--- a/__tests__/integration/biolink_based_resolver.test.ts
+++ b/__tests__/integration/biolink_based_resolver.test.ts
@@ -115,4 +115,13 @@ describe("Test ID Resolver", () => {
         expect(res['NCBIGENE:1017'][0].label).toEqual("CDK2");
         expect(res['NCBIGENE:1017'][1]).toBeInstanceOf(IrresolvableBioEntity);
     })
+
+    test("Test input with multiple colons in it should just be classified as irresolvable but not cause an error", async () => {
+        const resolver = new BioLinkBasedResolver();
+        const res = await resolver.resolve({ "Gene": ["NCBIGENE:GENE:1017"] });
+        expect(res).toHaveProperty("NCBIGENE:GENE:1017");
+        expect(res["NCBIGENE:GENE:1017"]).toHaveLength(1);
+        expect(res['NCBIGENE:GENE:1017'][0]).toBeInstanceOf(IrresolvableBioEntity);
+        expect(res['NCBIGENE:GENE:1017'][0].primaryID).toEqual("NCBIGENE:GENE:1017");
+    })
 })

--- a/__tests__/unittest/utils.test.ts
+++ b/__tests__/unittest/utils.test.ts
@@ -123,6 +123,12 @@ describe("Test Utils Module", () => {
             const res = generateDBID(input);
             expect(res).toEqual('1017');
         })
+
+        test("id with multiple colons in it should only trim the chars before the first occurrence of colon", () => {
+            const input = 'WIKIPATHWAYS:pathway:1017';
+            const res = generateDBID(input);
+            expect(res).toEqual('pathway:1017');
+        })
     })
 
     describe("Test generateIDTypeDict function", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ export function getPrefixFromCurie(curie: string): string {
 
 export function generateDBID(val: string): string {
   if (!CURIE.ALWAYS_PREFIXED.includes(val.split(':')[0])) {
-    return val.split(':').slice(-1)[0];
+    return val.substring(val.indexOf(':') + 1);
   } else {
     return val;
   }


### PR DESCRIPTION
close: #46 